### PR TITLE
Blob validation error doesn't set error response header.

### DIFF
--- a/lib/middleware/blob/validation.js
+++ b/lib/middleware/blob/validation.js
@@ -68,8 +68,8 @@ module.exports = (req, res, next) => {
     // Refactor me: Move this to bin/azurite (exception needs to carry res object), and handle entire exception handling there
   }).catch((e) => {
     res.status(e.statusCode || 500);
-    if(e.errorCode) { res.set(HttpHeaderNames.ERROR_CODE, e.errorCode) };
-    if(e.messageContentType) { res.type(e.messageContentType) };
+    if (e.errorCode) { res.set(HttpHeaderNames.ERROR_CODE, e.errorCode) };
+    if (e.messageContentType) { res.type(e.messageContentType) };
     res.send(e.message);
     if (!e.statusCode) throw e;
   });

--- a/lib/middleware/blob/validation.js
+++ b/lib/middleware/blob/validation.js
@@ -44,7 +44,8 @@ const BbPromise = require("bluebird"),
   ServiceSignatureValidation = require("./../../validation/blob/ServiceSignature"),
   ServicePropertiesValidation = require("./../../validation/blob/ServiceProperties"),
   ContainerNameValidation = require("./../../validation/blob/ContainerName"),
-  CopyStatusValidation = require("./../../validation/blob/CopyStatus");
+  CopyStatusValidation = require("./../../validation/blob/CopyStatus"),
+  HttpHeaderNames = require('./../../core/HttpHeaderNames');
 
 module.exports = (req, res, next) => {
   BbPromise.try(() => {
@@ -66,7 +67,10 @@ module.exports = (req, res, next) => {
     next();
     // Refactor me: Move this to bin/azurite (exception needs to carry res object), and handle entire exception handling there
   }).catch((e) => {
-    res.status(e.statusCode || 500).send(e.message);
+    res.status(e.statusCode || 500);
+    if(e.errorCode) { res.set(HttpHeaderNames.ERROR_CODE, e.errorCode) };
+    if(e.messageContentType) { res.type(e.messageContentType) };
+    res.send(e.message);
     if (!e.statusCode) throw e;
   });
 };


### PR DESCRIPTION
Features added:
- Added to Azurite\lib\middleware\blob\validation.js setting error response header.

Reason:
Azure Event Hub Client awaits error response header for classification error.